### PR TITLE
Set issue tracker to GitHub issues in metadata

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,6 +25,9 @@ WriteMakefile(
     META_MERGE => {
         'meta-spec' => { version => 2 },
         'resources' => {
+            bugtracker => {
+                web => 'https://github.com/giterlizzi/perl-URI-PackageURL/issues',
+            },
             repository => {
                 type => 'git',
                 url  => 'git://github.com/giterlizzi/perl-URI-PackageURL',


### PR DESCRIPTION
The module documentation points to GitHub issues as the bug tracker. Add the link to the dist metadata so MetaCPAN or other sites link to it properly.