### PR TITLE
add missing imports

### DIFF
--- a/lib/URI/PackageURL/Util.pm
+++ b/lib/URI/PackageURL/Util.pm
@@ -8,6 +8,7 @@ use warnings;
 use File::Spec;
 use File::Basename qw(dirname basename);
 use Exporter       qw(import);
+use Carp ();
 
 our $VERSION = '2.24';
 our @EXPORT  = qw(purl_to_urls purl_types);

--- a/lib/URI/VersionRange/Util.pm
+++ b/lib/URI/VersionRange/Util.pm
@@ -6,6 +6,7 @@ use utf8;
 use warnings;
 
 use Exporter qw(import);
+use Carp ();
 
 our $VERSION = '2.24';
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
URI-PackageURL.
We thought you might be interested in it too.

    Description: add missing imports
     Detected with `perl -wc $modulefile`.
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2026-01-26
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/liburi-packageurl-perl/raw/master/debian/patches/use-carp.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
